### PR TITLE
1.0.8

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -398,6 +398,27 @@ function nimblepress_get_web_safe_fonts() {
 
 }
 
+/**
+ * List of text decorations
+ */
+ 
+function nimblepress_get_text_decorations() {
+
+	return array(
+		'none' => 'None',
+		'underline' => 'Underline',
+		'underline dotted' => 'Underline dotted',
+		'underline dashed' => 'Underline dashed',
+		'underline dotted' => 'Underline dotted',
+		'overline' => 'Overline',
+		'overline dotted' => 'Overline  dotted',
+		'overline dashed' => 'Overline  dashed',
+		'overline dotted' => 'Overline  dotted',
+	
+	);
+
+}
+
 
 /**
  * Add NP meta boxes
@@ -707,27 +728,69 @@ function nimblepress_customizer_styles()
 
     ?>
          <style type="text/css">
+
 			body {
 				background-color: <?php echo esc_html( get_theme_mod('np_body_background_color', '') ); ?>;
 				font-family: <?php echo esc_html( get_theme_mod('np_body_font', 'Helvetica') ); ?>, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 			}
+
 			h1, h2, h3, h4, h5, h6 {
 				font-family: <?php echo esc_html( get_theme_mod('np_heading_font', 'Helvetica') ); ?>, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 				color: <?php echo esc_html( get_theme_mod('np_heading_color', '#404040') ); ?>;
 			}
-			.nav-menu a:link, .nav-menu a:active, .nav-menu a:visited, .nav-menu a:hover {
+
+			a:link, a:active, a:visited {
+				color: <?php echo esc_html( get_theme_mod('np_link_color', '#1e73be') ); ?>;
+				font-family: <?php echo esc_html( get_theme_mod('np_link_font', 'Helvetica') ); ?>, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+				text-decoration: <?php echo esc_html( get_theme_mod('np_link_text_decoration', 'none') ); ?>;
+			}
+
+			a:hover {
+				color: <?php echo esc_html( get_theme_mod('np_link_hover_color', '#1e73be') ); ?>;
+				font-family: <?php echo esc_html( get_theme_mod('np_link_font', 'Helvetica') ); ?>, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+				text-decoration: <?php echo esc_html( get_theme_mod('np_link_hover_text_decoration', 'underline') ); ?>;
+			}
+
+			.entry-title a:link, .entry-title a:active, .entry-title a:visited {
+				color: <?php echo esc_html( get_theme_mod('np_heading_link_color', '#1e73be') ); ?>;
+				font-family: <?php echo esc_html( get_theme_mod('np_heading_font', 'Helvetica') ); ?>, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+				text-decoration: <?php echo esc_html( get_theme_mod('np_entry_title_link_text_decoration', 'none') ); ?>;
+			}
+
+			.entry-title a:hover {
+				color: <?php echo esc_html( get_theme_mod('np_heading_link_hover_color', '#1e73be') ); ?>;
+				text-decoration: <?php echo esc_html( get_theme_mod('np_entry_title_link_hover_text_decoration', 'underline') ); ?>;
+			}
+
+			.footer-wrapper a:link, .footer-wrapper a:active, .footer-wrapper a:visited {
+				color: <?php echo esc_html( get_theme_mod('np_footer_link_color', '#1e73be') ); ?>;
+			}
+
+			.footer-wrapper {
+				color: <?php echo esc_html( get_theme_mod('np_footer_text_color', '#404040') ); ?>;
+			}
+
+			.footer-wrapper a:hover {
+				color: <?php echo esc_html( get_theme_mod('np_footer_link_hover_color', '#1e73be') ); ?>;
+			}
+
+			.entry-content a:link, .entry-content a:visited, .entry-content a:active, .comment-content a:link, .comment-content a:visited, .comment-content a:active, .widget_text a:link, .widget_text a:visited, .widget_text a:active {
+				text-decoration: <?php echo esc_html( get_theme_mod('np_content_link_text_decoration', 'underline') ); ?>;
+			}
+
+			.entry-content a:hover, .comment-content a:hover, .widget_text a:hover {
+				text-decoration: <?php echo esc_html( get_theme_mod('np_content_link_hover_text_decoration', 'underline') ); ?>;
+			}
+
+			.nimblepress-menu-link a:link, .nimblepress-menu-link a:active, .nimblepress-menu-link a:visited {
 				font-family: <?php echo esc_html( get_theme_mod('np_nav_menu_font', 'Helvetica') ); ?>, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 				color: <?php echo esc_html( get_theme_mod('np_menu_link_color', '#1e73be') ); ?>;
 			}
-			a:link, a:active, a:visited, a:hover {
-				font-family: <?php echo esc_html( get_theme_mod('np_link_font', 'Helvetica') ); ?>, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
+			.nimblepress-menu-link a:hover {
+				color: <?php echo esc_html( get_theme_mod('np_menu_link_hover_color', '#1e73be') ); ?>;
 			}
-			a:not(.read-more):not(.button):link, a:not(.read-more):not(.button):active, a:not(.read-more):not(.button):visited {
-				color: <?php echo esc_html( get_theme_mod('np_link_color', '#1e73be') ); ?>;
-			}
-			a:not(.read-more):not(.button):hover {
-				color: <?php echo esc_html( get_theme_mod('np_link_hover_color', '#4aabc9') ); ?>;
-			}
+
 			#page {
 				<?php if ( esc_html( get_theme_mod( 'np_site_full_width_or_contained', 'full_width' ) ) == 'contained' ): ?>
 				max-width : <?php echo esc_html( get_theme_mod('np_site_width', '1200') ); ?>px;
@@ -742,18 +805,22 @@ function nimblepress_customizer_styles()
 					box-shadow: 0 2px 8px 2px rgba(<?php echo esc_html( nimblepress_hex_to_rgb( get_theme_mod( 'np_site_shadow_color', '#ffffff' ) ) );  ?>,0.1);
 				<?php endif ?>
 			}
+
 			#main-content {
 				max-width : <?php echo esc_html( get_theme_mod('np_np_site_width', '1200') ); ?>px;
 				<?php if ( esc_html( get_theme_mod('np_site_background_color', '') ) != '' ): ?>
 					background-color: <?php echo esc_html( get_theme_mod('np_body_background_color', '') ); ?>;
 				<?php endif ?>
 			}
+
 			.site-header-wrapper {
 				max-width : <?php echo esc_html( get_theme_mod('np_site_width', '1200') ); ?>px;
 			}
+
 			.footer-wrapper {
 				max-width : <?php echo esc_html( get_theme_mod('np_site_width', '1200') ); ?>px;
 			}
+
 			.site-header {
 				background-color: <?php echo esc_html( get_theme_mod('np_header_background_color', '#fbfbfb') ); ?>;
 				box-shadow: 0 1px 8px 1px rgba(<?php echo nimblepress_hex_to_rgb( get_theme_mod( 'np_header_shadow', '#000000' ) ) ?>,0.08);
@@ -761,6 +828,7 @@ function nimblepress_customizer_styles()
 					min-height : <?php echo esc_html( get_theme_mod( 'np_header_height', 'auto' ) ); ?>px;
 				<?php endif ?>
 			}
+
 			.site-footer {
 				background-color: <?php echo esc_html( get_theme_mod('np_footer_background_color', '#fbfbfb') ); ?>;
 				box-shadow: 0 -1px 8px 1px rgba(<?php echo nimblepress_hex_to_rgb( esc_html( get_theme_mod( 'np_footer_shadow', '#000000' ) ) ) ?>,0.08);
@@ -768,20 +836,23 @@ function nimblepress_customizer_styles()
 					min-height : <?php echo esc_html( get_theme_mod('np_footer_height', 'auto') ); ?>px;
 				<?php endif ?>
 			}
+
 			.widget {
 				background-color: <?php echo esc_html( get_theme_mod('np_widget_background_color', '#ffffff') ); ?>;
 				box-shadow: 0px 1px 8px rgba(<?php echo esc_html( nimblepress_hex_to_rgb( get_theme_mod( 'np_widget_shadow', '#000000' ) ) ) ?>, 0.08);
 			}
 						
-			button, .read-more, html input[type="button"], input[type="reset"], input[type="submit"], a.button, a.wp-block-button__link:not(.has-background) {
+			button, .read-more, html input[type="button"], input[type="reset"], input[type="submit"], a.button:link, a.button:visited, a.button:active, a.wp-block-button__link:not(.has-background) {
 				color: <?php echo esc_html( get_theme_mod('np_button_text_color', '#ffffff') ); ?>;
 				background-color: <?php echo esc_html( get_theme_mod('np_button_background_color', '#2f4d80') ); ?>;
+				text-decoration: none;
 			}
 
 			button:hover, .read-more:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover, a.button:hover, button:focus, html input[type="button"]:focus, input[type="reset"]:focus, input[type="submit"]:focus, a.button:focus, a.wp-block-button__link:not(.has-background):active, a.wp-block-button__link:not(.has-background):focus, a.wp-block-button__link:not(.has-background):hover {
-				color: <?php echo esc_html( get_theme_mod('np_button_text_color', '#ffffff') ); ?>;
+				color: <?php echo esc_html( get_theme_mod('np_button_hover_text_color', '#ffffff') ); ?>;
 				background-color: <?php echo esc_html( get_theme_mod('np_button_hover_background_color', '#4075cb') ); ?>;
 				cursor: pointer;
+				text-decoration: none;
 			}
 			
 			.nav-menu a:hover {
@@ -792,9 +863,11 @@ function nimblepress_customizer_styles()
 				font-size: <?php echo esc_html( get_theme_mod('site_title_size', '42') ); ?>px;
 				
 			}
+
 			.site-title a:link, .site-title a:visited, .site-title a:active, .site-title a:hover {
 				color: <?php echo esc_html( get_theme_mod('np_site_title_color', '#1e73be') ); ?>;
 			}
+
 			.site-description {
 				color: <?php echo esc_html( get_theme_mod('np_site_description_color', '#404040') ); ?>;
 				font-size: <?php echo esc_html( get_theme_mod('site_description_font_size', '16') ); ?>px;
@@ -861,7 +934,6 @@ function nimblepress_chevron_to_nav_menu( $item_output, $item, $depth, $args ) {
 
 }
 
-
 add_filter( 'walker_nav_menu_start_el', 'nimblepress_chevron_to_nav_menu', 10, 4 );
 
 
@@ -875,7 +947,8 @@ function nimblepress_genereate_footer_info( $args = array() ) {
 	
 		$do_footer = ' © ' . date('Y') . ' ' . get_bloginfo( 'name' );
 		$do_footer .= ' | ';
-		$do_footer .= sprintf( esc_html__( 'Built with %1$s', 'nimblepress' ), '<a href="https://codebard.com/nimblepress" target="blank">NimblePress</a>' );
+		$do_footer .= esc_html__( 'Built with ', 'nimblepress' ); 
+		$do_footer .= '<a href="https://codebard.com/nimblepress" target="blank">&nbsp;NimblePress</a>';
 		
 		echo $do_footer;
 }

--- a/functions.php
+++ b/functions.php
@@ -873,9 +873,9 @@ add_action('nimblepress_genereate_footer_info', 'nimblepress_genereate_footer_in
 
 function nimblepress_genereate_footer_info( $args = array() ) {
 	
-		$do_footer = '&nbsp;©&nbsp;' . date('Y') . '&nbsp;' . get_bloginfo( 'name' );
-		$do_footer .= '&nbsp;|&nbsp;';
-		$do_footer .= sprintf( esc_html__( 'Built with&nbsp;%1$s', 'nimblepress' ), '<a href="https://codebard.com/nimblepress" target="blank">NimblePress</a>' );
+		$do_footer = ' © ' . date('Y') . ' ' . get_bloginfo( 'name' );
+		$do_footer .= ' | ';
+		$do_footer .= sprintf( esc_html__( 'Built with %1$s', 'nimblepress' ), '<a href="https://codebard.com/nimblepress" target="blank">NimblePress</a>' );
 		
 		echo $do_footer;
 }

--- a/header.php
+++ b/header.php
@@ -82,6 +82,7 @@ if ( isset( $post ) AND $post AND isset( $post->ID ) ) {
 							array(
 								'theme_location' => 'menu-1',
 								'menu_id'        => 'primary-menu',
+								'menu_class' => 'menu nav-menu',
 							)
 						);
 						?>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -209,12 +209,35 @@ function nimblepress_customize_register( $wp_customize )
 		'sanitize_callback' => 'wp_filter_nohtml_kses',
 	) );
 
-	$wp_customize->add_setting( 'np_link_color' , array(
+	$wp_customize->add_setting( 'np_footer_link_color' , array(
 		'default'   => '#1e73be',
 		'transport' => 'refresh',
 		'sanitize_callback' => 'wp_filter_nohtml_kses',
 	) );
 
+	$wp_customize->add_setting( 'np_footer_text_color' , array(
+		'default'   => '#404040',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_footer_link_hover_color' , array(
+		'default'   => '#1e73be',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_menu_link_hover_color' , array(
+		'default'   => '#1e73be',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_link_color' , array(
+		'default'   => '#1e73be',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
 
 	$wp_customize->add_setting( 'np_link_hover_color' , array(
 		'default'   => '#4aabc9',
@@ -222,8 +245,56 @@ function nimblepress_customize_register( $wp_customize )
 		'sanitize_callback' => 'wp_filter_nohtml_kses',
 	) );
 
+	$wp_customize->add_setting( 'np_link_text_decoration' , array(
+		'default'   => 'none',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+	
+	$wp_customize->add_setting( 'np_link_hover_text_decoration' , array(
+		'default'   => 'underline',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_content_link_text_decoration' , array(
+		'default'   => 'underline',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+	
+	$wp_customize->add_setting( 'np_content_link_hover_text_decoration' , array(
+		'default'   => 'underline',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_entry_title_link_text_decoration' , array(
+		'default'   => 'none',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+	
+	$wp_customize->add_setting( 'np_entry_title_link_hover_text_decoration' , array(
+		'default'   => 'underline',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
 	$wp_customize->add_setting( 'np_heading_color' , array(
 		'default'   => '#404040',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_heading_link_color' , array(
+		'default'   => '#1e73be',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_heading_link_hover_color' , array(
+		'default'   => '#1e73be',
 		'transport' => 'refresh',
 		'sanitize_callback' => 'wp_filter_nohtml_kses',
 	) );
@@ -248,6 +319,12 @@ function nimblepress_customize_register( $wp_customize )
 
 
 	$wp_customize->add_setting( 'np_button_text_color' , array(
+		'default'   => '#ffffff',
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_filter_nohtml_kses',
+	) );
+
+	$wp_customize->add_setting( 'np_button_hover_text_color' , array(
 		'default'   => '#ffffff',
 		'transport' => 'refresh',
 		'sanitize_callback' => 'wp_filter_nohtml_kses',
@@ -429,6 +506,22 @@ function nimblepress_customize_register( $wp_customize )
 		'priority'              => 19,
 	) ) );
 	
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_heading_link_color', array(
+		'label'      => __( 'Heading Link Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'Color for heading links in post listings', 'nimblepress' ),
+		'settings'   => 'np_heading_link_color',
+		'priority'              => 19,
+	) ) );
+	
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_heading_link_hover_color', array(
+		'label'      => __( 'Heading Link Hover Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'Hover color for heading links in post listings', 'nimblepress' ),
+		'settings'   => 'np_heading_link_hover_color',
+		'priority'              => 19,
+	) ) );
+	
 	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_button_background_color', array(
 		'label'      => __( 'Button Background Color', 'nimblepress' ),
 		'section'    => 'colors',
@@ -445,13 +538,41 @@ function nimblepress_customize_register( $wp_customize )
 		'priority'              => 21,
 	) ) );
 	
+
+	
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_button_text_color', array(
+		'label'      => __( 'Button Text Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'The color for the text on the buttons.', 'nimblepress' ),
+		'settings'   => 'np_button_text_color',
+		'priority'              => 22,
+	) ) );
+	
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_button_hover_text_color', array(
+		'label'      => __( 'Button Hover Text Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'The color for the text on the buttons when hovered.', 'nimblepress' ),
+		'settings'   => 'np_button_hover_text_color',
+		'priority'              => 23,
+	) ) );
+
+	
 	
 	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_menu_link_color', array(
 		'label'      => __( 'Menu Link Color', 'nimblepress' ),
 		'section'    => 'colors',
-		'description' => __( 'Colors of link in the header menu.', 'nimblepress' ),
+		'description' => __( 'Colors of link text in the header menu.', 'nimblepress' ),
 		'settings'   => 'np_menu_link_color',
-		'priority'              => 22,
+		'priority'              => 23,
+	) ) );
+	
+	
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_menu_link_hover_color', array(
+		'label'      => __( 'Menu Link Hover Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'Colors of link text in the header menu when hovered.', 'nimblepress' ),
+		'settings'   => 'np_menu_link_hover_color',
+		'priority'              => 23,
 	) ) );
 	
 	
@@ -463,20 +584,36 @@ function nimblepress_customize_register( $wp_customize )
 		'priority'              => 23,
 	) ) );
 	
-	
-	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_button_text_color', array(
-		'label'      => __( 'Button Text Color', 'nimblepress' ),
-		'section'    => 'colors',
-		'description' => __( 'The color for the text on the buttons.', 'nimblepress' ),
-		'settings'   => 'np_button_text_color',
-		'priority'              => 24,
-	) ) );
-
 	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_footer_background_color', array(
 		'label'      => __( 'Footer Background Color', 'nimblepress' ),
 		'section'    => 'colors',
 		'description' => __( 'Background color of the footer', 'nimblepress' ),
 		'settings'   => 'np_footer_background_color',
+		'priority'              => 25,
+	) ) );
+
+	
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_footer_text_color', array(
+		'label'      => __( 'Footer Text Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'Color of the text in the footer', 'nimblepress' ),
+		'settings'   => 'np_footer_text_color',
+		'priority'              => 25,
+	) ) );
+	
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_footer_link_color', array(
+		'label'      => __( 'Footer Link Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'Color of the links in the footer', 'nimblepress' ),
+		'settings'   => 'np_footer_link_color',
+		'priority'              => 25,
+	) ) );
+
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'np_footer_link_hover_color', array(
+		'label'      => __( 'Footer Hover Link Color', 'nimblepress' ),
+		'section'    => 'colors',
+		'description' => __( 'Color of the links in the footer when hovered', 'nimblepress' ),
+		'settings'   => 'np_footer_link_hover_color',
 		'priority'              => 25,
 	) ) );
 
@@ -657,6 +794,90 @@ function nimblepress_customize_register( $wp_customize )
 				'section'    => 'np_fonts',
 				'type'    => 'select',
 				'choices' => nimblepress_get_web_safe_fonts()
+			)
+	) );
+
+	$wp_customize->add_control( new WP_Customize_Control(
+		$wp_customize, //Pass the $wp_customize object (required)
+			'np_link_text_decoration', //Set a unique ID for the control
+			array(
+				'label'      => __( 'Link Text Decoration', 'nimblepress' ),
+				'description' => __( 'Decoration for the links across the site', 'nimblepress' ),
+				'settings'   => 'np_link_text_decoration',
+				'priority'   => 10,
+				'section'    => 'np_fonts',
+				'type'    => 'select',
+				'choices' => nimblepress_get_text_decorations()
+			)
+	) );
+
+	$wp_customize->add_control( new WP_Customize_Control(
+		$wp_customize, //Pass the $wp_customize object (required)
+			'np_link_hover_text_decoration', //Set a unique ID for the control
+			array(
+				'label'      => __( 'Link Hover Text Decoration', 'nimblepress' ),
+				'description' => __( 'Decoration for the links across the site when hovered', 'nimblepress' ),
+				'settings'   => 'np_link_hover_text_decoration',
+				'priority'   => 10,
+				'section'    => 'np_fonts',
+				'type'    => 'select',
+				'choices' => nimblepress_get_text_decorations()
+			)
+	) );
+
+	$wp_customize->add_control( new WP_Customize_Control(
+		$wp_customize, //Pass the $wp_customize object (required)
+			'np_entry_title_link_text_decoration', //Set a unique ID for the control
+			array(
+				'label'      => __( 'Heading Link Text Decoration', 'nimblepress' ),
+				'description' => __( 'Decoration for the post headings links in post listings', 'nimblepress' ),
+				'settings'   => 'np_entry_title_link_text_decoration',
+				'priority'   => 10,
+				'section'    => 'np_fonts',
+				'type'    => 'select',
+				'choices' => nimblepress_get_text_decorations()
+			)
+	) );
+
+	$wp_customize->add_control( new WP_Customize_Control(
+		$wp_customize, //Pass the $wp_customize object (required)
+			'np_entry_title_link_hover_text_decoration', //Set a unique ID for the control
+			array(
+				'label'      => __( 'Heading Link Hover Text Decoration', 'nimblepress' ),
+				'description' => __( 'Decoration for the post headings links in post listings when hovered', 'nimblepress' ),
+				'settings'   => 'np_entry_title_link_hover_text_decoration',
+				'priority'   => 10,
+				'section'    => 'np_fonts',
+				'type'    => 'select',
+				'choices' => nimblepress_get_text_decorations()
+			)
+	) );
+
+	$wp_customize->add_control( new WP_Customize_Control(
+		$wp_customize, //Pass the $wp_customize object (required)
+			'np_content_link_text_decoration', //Set a unique ID for the control
+			array(
+				'label'      => __( 'In-content Links Text Decoration', 'nimblepress' ),
+				'description' => __( 'Decoration for the the links in post contents and text widget contents', 'nimblepress' ),
+				'settings'   => 'np_content_link_text_decoration',
+				'priority'   => 10,
+				'section'    => 'np_fonts',
+				'type'    => 'select',
+				'choices' => nimblepress_get_text_decorations()
+			)
+	) );
+
+	$wp_customize->add_control( new WP_Customize_Control(
+		$wp_customize, //Pass the $wp_customize object (required)
+			'np_content_link_hover_text_decoration', //Set a unique ID for the control
+			array(
+				'label'      => __( 'In-content Links Hover Text Decoration', 'nimblepress' ),
+				'description' => __( 'Decoration for the the links in post contents and text widget contents when hovered', 'nimblepress' ),
+				'settings'   => 'np_content_link_hover_text_decoration',
+				'priority'   => 10,
+				'section'    => 'np_fonts',
+				'type'    => 'select',
+				'choices' => nimblepress_get_text_decorations()
 			)
 	) );
 

--- a/languages/nimblepress.pot
+++ b/languages/nimblepress.pot
@@ -566,3 +566,12 @@ msgstr ""
 #. Go premium for more features
 msgid "Go premium for more features"
 msgstr ""
+
+
+#. Link Text Decoration
+msgid "Link Text Decoration"
+msgstr ""
+
+#. Decoration for the links across the site
+msgid "Decoration for the links across the site"
+msgstr ""

--- a/style.css
+++ b/style.css
@@ -1577,19 +1577,6 @@ button:hover, .read-more:hover, html input[type="button"]:hover, input[type="res
 	text-decoration: underline;
 }
 
-.widget_text button, .button:link, .button:visited, .button:active  {
-    color: #ffffff;
-    background-color: #2f4d80;
-	text-decoration: none;
-}
-
-
-.widget_text button:hover,  .button:hover {
-    color: #ffffff;
-    background-color: #4075cb;
-	cursor: pointer;
-	text-decoration: none;
-}
 
 .widget h2 {
 	font-size: 1.25em;

--- a/style.css
+++ b/style.css
@@ -952,7 +952,6 @@ body {
 
 .widget {
     margin: 0 0 30px;
-	padding : 
     box-sizing: border-box;
 	box-shadow: rgba(0, 0, 0, 0.08) 0px 4px 16px;
 }
@@ -1360,14 +1359,17 @@ button:hover, .read-more:hover, html input[type="button"]:hover, input[type="res
 }
 
 .footer-widget {
-	width: 300px;
+	flex-basis: fit-content;
+	max-width: 350px;
 	flex-flow: column;
 	padding: 10px;
 }
 
 .site-info {
   display: flex;
+  flex-flow: row wrap;
   flex-grow: 1;
+  flex-shrink: 1;
   min-width: 100%;
   align-items: center;
   justify-content: center;
@@ -1425,13 +1427,13 @@ button:hover, .read-more:hover, html input[type="button"]:hover, input[type="res
 	.site-header-wrapper {
 		
 		display: flex;
-		flex-direction: row;
 		flex-flow: row wrap;
 		justify-content: flex-start;
 	}
 	
-	.site-branding {
-		width: 100%;
+	.site-branding img {
+		width: 100% !important;
+		height: auto !important;
 	}
 	
 	.main-navigation {


### PR DESCRIPTION
- Fixed issue with nav menu getting squashed in some sites when in customizer
- Made mobile nav menu responsive - now it stays to top right if logo is small and device has enough width to save header height
- Fixed a css property that did not have a value and semicolon
- Footer widget size now auto-scales depending on its content
- Made site info shrink and wrap to accommodate long site names
- Fixed some link buttons not getting styled by button styling
- Added link color, link hover color and text decoration customization
- Added in-entry, in-widget link color, hover color and text decoration customization
- Added heading link color, hover color and text decoration customization
- Added footer link color, hover color customization
- Added footer text color customization